### PR TITLE
Add exclude glob option in wget job

### DIFF
--- a/docker/hysds-io.json.lw-tosca-wget-glob
+++ b/docker/hysds-io.json.lw-tosca-wget-glob
@@ -14,11 +14,18 @@
       "from": "submitter"
     },
     {
-      "name": "glob",
+      "name": "include_glob",
       "type": "text",
       "from": "submitter",
-      "default": "N_*fn*_logra2a1.tif,N_*logamp*.tif,*.dem*,N_*_msk.tif",
+      "default": "*final*",
       "placeholder": "A comma seperated list of globs to download"
+    },
+    {
+      "name": "exclude_glob",
+      "type": "text",
+      "from": "submitter",
+      "default": "*tiles*",
+      "placeholder": "A comma seperated list of globs to exclude from included list"
     },
     {
       "name": "name",

--- a/docker/job-spec.json.lw-tosca-wget-glob
+++ b/docker/job-spec.json.lw-tosca-wget-glob
@@ -17,7 +17,11 @@
       "destination": "positional"
     },
     {
-      "name": "glob",
+      "name": "include_glob",
+      "destination": "context"
+    },
+    {
+      "name": "exclude_glob",
       "destination": "context"
     }
    ]

--- a/wget.py
+++ b/wget.py
@@ -194,8 +194,6 @@ def glob_filter(names, glob_dict):
             files.extend(matching)
         print("Got the following files to include: %s" % str(files))
 
-
-    # TODO: continue working from here, we need to find a way to esclude from the current file list
     if exclude_csv:
         pattern_list_exc = [item.strip() for item in exclude_csv.split(',')]
 


### PR DESCRIPTION
Added a field for user to define an exclude glob to exclude files for download.
(kinda like rsync but still different)
From now users can define:
`include_glob`  and `exclude_glob` 
^ both are comma-separated list of globs(wildcards) to include and exclude files. 
Sequence:
1.) Job will create a list of files in `include_glob` first. 
2.) From the list of files in (1), job will remove files that matches `exclude_glob`

[Test logs](https://gist.github.com/shitong01/85193f64ee161af1c0785c1859f3a57c)